### PR TITLE
Breaking: Added context parameter to `Try()` function. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,9 @@ This code is licensed under the MIT License. See the LICENSE file for details.
   - Added context parameter to `Try()` function. 
   - Immediate reaction to context cancellation implemented. 
   - `re.Sleep(ctx, duration)` function added to support context-aware sleeping.
+  - Improved processing when timeout is reached: 
+    - We run `fn` one last time before the timeout. 
+    - This ensures the final sleep period isn't wasted, especially in Backoff scenarios where that last wait could be long.
+
 - **v0.0.1** 
   - Initial release with basic retry functionality and default policies.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The function accepts two parameters:
 If no retry policy is specified, `re.Const()` is used by default, with a 30-second timeout and a 1-second interval between attempts.
 
 ```go
-db, err := re.Try(func() (*sql.DB, error) {
+db, err := re.Try(ctx, func() (*sql.DB, error) {
     return sql.Open("mysql", dsn)
 })
 ```
@@ -29,7 +29,7 @@ The `Backoff` policy in its default configuration has a 2-minute timeout with a 
 fn := func() (*sql.DB, error) {
     return sql.Open("mysql", dsn)
 }
-db, err := re.Try(fn, re.Backoff())
+db, err := re.Try(ctx, fn, re.Backoff())
 ```
 
 ## Fully Customized Backoff Retry Policy
@@ -38,7 +38,7 @@ fn := func() (*sql.DB, error) {
     return sql.Open("mysql", dsn)
 }
 // Genrates the following sleep durations: 100ms, 300ms, 900ms, 2.7s, 8.1s, 24.3s, 60s, 60s, ...
-db, err := re.Try(fn, re.Backoff().WithFactor(3).WithInterval(100*time.Millisecond).WithMaxInterval(60*time.Second).WithTimeout(5*time.Minute))
+db, err := re.Try(ctx, fn, re.Backoff().WithFactor(3).WithInterval(100*time.Millisecond).WithMaxInterval(60*time.Second).WithTimeout(5*time.Minute))
 ```
 
 # Custom Retry Policies
@@ -84,10 +84,14 @@ func (c *CustomPolicy) Failures() int {
 fn := func() (*sql.DB, error) {
     return sql.Open("mysql", dsn)
 }
-db, err := re.Try(fn, Custom().WithTimeout(1*time.Minute))
+db, err := re.Try(ctx, fn, Custom().WithTimeout(1*time.Minute))
 ```
 
-
+# How to Run Linter
+To run the linter, use the following command in the terminal:
+```bash
+golangci-lint run --fix --build-tags=tests
+```
 
 
 # Contributing
@@ -98,3 +102,10 @@ Contributions are welcome! Please open an issue or submit a pull request on GitH
 # License
 This code is licensed under the MIT License. See the LICENSE file for details.
 
+# Changelog
+- **v1.0.0** 
+  - Added context parameter to `Try()` function. 
+  - Immediate reaction to context cancellation implemented. 
+  - `re.Sleep(ctx, duration)` function added to support context-aware sleeping.
+- **v0.0.1** 
+  - Initial release with basic retry functionality and default policies.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -26,9 +27,11 @@ func failFunc() (int, error) {
 }
 
 func main() {
+	ctx := context.Background()
+
 	// Try default policy (Const) with ok result
 	fmt.Println("--- okFunc() on default ConstPolicy --- ")
-	i, err := re.Try(okFunc)
+	i, err := re.Try(ctx, okFunc)
 	if err != nil {
 		panic("Unexpected error: " + err.Error())
 	}
@@ -43,7 +46,7 @@ func main() {
 	fmt.Println("Start time=", start)
 	fmt.Println("Timout time=", start.Add(5*time.Second))
 
-	i, err = re.Try(failFunc, re.Const().WithInterval(2*time.Second).WithTimeout(5*time.Second))
+	i, err = re.Try(ctx, failFunc, re.Const().WithInterval(2*time.Second).WithTimeout(5*time.Second))
 	if err != nil {
 		fmt.Println("End time=", time.Now())
 		fmt.Println("failFunc() failed with", err.Error(), "after", time.Since(start))
@@ -68,7 +71,7 @@ func main() {
 
 	fmt.Println("Expected sleeps:", expectedSleeps)
 
-	i, err = re.Try(okFunc, customPolicy)
+	i, err = re.Try(ctx, okFunc, customPolicy)
 	if err != nil {
 		panic("Unexpected error: " + err.Error())
 	}

--- a/re/retry.go
+++ b/re/retry.go
@@ -14,7 +14,7 @@ type TryPolicy interface {
 	WithTimeout(timeout time.Duration) TryPolicy
 }
 
-// Try - from app called as `re.Try(fn)` retries the given function until it succeeds or time is exceeded.
+// Try - from app called as `re.Try(ctx, fn)` - retries the given function until it succeeds or time is exceeded.
 // TryPolicy specifies how waiting is processed and the timeout.
 func Try[T any](ctx context.Context, fn func() (T, error), rp ...TryPolicy) (T, error) {
 	var zero T

--- a/re/retry_test.go
+++ b/re/retry_test.go
@@ -171,7 +171,7 @@ func (s *RetryTestSuite) TestRetryContextCanceled() {
 
 	// ACT
 	go func() {
-		time.Sleep(11 * time.Millisecond) // ensure that the first attempt is made before canceling the context
+		time.Sleep(15 * time.Millisecond) // ensure that the first attempt is made before canceling the context
 		cancel()
 	}()
 	result, err := Try(ctx, fn, Const().WithInterval(10*time.Millisecond).WithTimeout(60*time.Millisecond))
@@ -207,7 +207,7 @@ func (s *RetryTestSuite) TestSleep() {
 
 	// ACT
 	go func() {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(15 * time.Millisecond)
 		cancel()
 	}()
 	err := Sleep(ctx, 20*time.Millisecond)


### PR DESCRIPTION
  - Added context parameter to `Try()` function. 
  - Immediate reaction to context cancellation implemented. 
  - `re.Sleep(ctx, duration)` function added to support context-aware sleeping.
  - Improved processing when timeout is reached: 
    - We run `fn` one last time before the timeout. 
    - This ensures the final sleep period isn't wasted, especially in Backoff scenarios where that last wait could be long.
  - README.md updated.